### PR TITLE
fix: Temporarily replace header tag with div in Header component

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -18,7 +18,7 @@ const navItems = [
 
 export function Header() {
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <div className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-16 max-w-screen-2xl items-center">
         <Link href="/" className="mr-6 flex items-center space-x-2 rtl:ml-6 rtl:mr-0">
           <School className="h-7 w-7 text-primary" />
@@ -71,7 +71,7 @@ export function Header() {
           </Sheet>
         </div>
       </div>
-    </header>
+    </div>
   );
 }
 


### PR DESCRIPTION
This change is an attempt to resolve an "Unexpected token header" error occurring during the Vercel build process. By changing `<header>` to `<div>`, we are testing if the issue is specific to the header tag itself or a more general JSX parsing problem.