### PR TITLE
fix: Correct Tailwind syntax in globals.css and restore Header

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,4 +1,4 @@
-// import { Header } from "@/components/layout/Header";
+import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { FloatingActionButton } from "@/components/layout/FloatingActionButton";
 
@@ -9,7 +9,7 @@ export default function MainLayout({
 }) {
   return (
     <div className="flex min-h-screen flex-col bg-gradient-to-b from-primary/5 via-background/30 to-background/80"> {/* Adjusted gradient */}
-      {/* <Header /> */}
+      <Header />
       <main className="flex-1">{children}</main>
       <Footer />
       <FloatingActionButton />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,8 +103,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground font-body antialiased;
-    transition-colors duration-300 ease-in-out; /* Smooth transition for theme changes */
+    @apply bg-background text-foreground font-body antialiased transition-colors duration-300 ease-in-out;
   }
   /* Define font-body if it's not already part of a Tailwind plugin */
   .font-body {


### PR DESCRIPTION
- Modified `globals.css` to correctly apply Tailwind transition utilities to the body tag using `@apply`.
- Restored the import and usage of the Header component in the main layout.

This addresses the CSS syntax error from the previous build and brings back the Header, hoping the original parsing issue with Header.tsx was incidentally resolved by earlier file rewrite actions.