### PR TITLE
Prevent duplicate toast listeners and handle missing city data

### DIFF
--- a/src/app/(main)/universities/[id]/page.tsx
+++ b/src/app/(main)/universities/[id]/page.tsx
@@ -39,7 +39,7 @@ async function getUniversityData(idOrNameFromUrl: string): Promise<University | 
         id: aiDetails.name, // Use the AI-provided name as the ID
         name: aiDetails.name,
         // Ensure other fields have fallbacks if not provided by AI
-        city: aiDetails.city,
+        city: aiDetails.city ?? 'N/A',
         annualFees: aiDetails.annualFees === undefined ? 'N/A' : Number(aiDetails.annualFees),
         availableCourses: aiDetails.availableCourses || [],
         description: aiDetails.description || 'No description available.',

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- stop `useToast` from re-subscribing on every state update to avoid duplicate listeners
- provide a default city when AI data omits it to satisfy `University` typing

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_689f2a20ceb0832499c6b886c352b893