### PR TITLE
Fix broken university image URLs with placeholder photos

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig = {
     // Keep it simple: serve images as-is (no domain headaches on Vercel)
     unoptimized: true,
     // (optional) if you later re-enable optimization, keep these:
-    domains: ['upload.wikimedia.org', 'placehold.co'],
+    domains: ['upload.wikimedia.org', 'placehold.co', 'picsum.photos'],
   },
 };
 

--- a/public/test.html
+++ b/public/test.html
@@ -7,10 +7,10 @@
 </head>
 <body>
     <h1>Testing University Images</h1>
-    <img src="/universities/uni1.png" alt="University 1" width="300">
-    <img src="/universities/uni2.png" alt="University 2" width="300">
-    <img src="/universities/uni3.png" alt="University 3" width="300">
-    <img src="/universities/uni4.png" alt="University 4" width="300">
-    <img src="/universities/uni5.png" alt="University 5" width="300">
+    <img src="https://picsum.photos/seed/uni1/300/200" alt="University 1" width="300">
+    <img src="https://picsum.photos/seed/uni2/300/200" alt="University 2" width="300">
+    <img src="https://picsum.photos/seed/uni3/300/200" alt="University 3" width="300">
+    <img src="https://picsum.photos/seed/uni4/300/200" alt="University 4" width="300">
+    <img src="https://picsum.photos/seed/uni5/300/200" alt="University 5" width="300">
 </body>
 </html>

--- a/src/components/SmartImage.tsx
+++ b/src/components/SmartImage.tsx
@@ -10,8 +10,9 @@ type Props = {
 };
 
 /**
- * A smart image component that falls back to a set of local placeholder images when
- * the provided source fails to load or is undefined.
+ * A smart image component that falls back to a set of remote placeholder images when
+ * the provided source fails to load or is undefined. This keeps broken URLs from
+ * rendering visibly on the page.
  */
 export default function SmartImage({
   src,
@@ -22,11 +23,11 @@ export default function SmartImage({
 }: Props) {
   const [error, setError] = useState(false);
   const fallbacks = [
-    '/universities/uni1.png',
-    '/universities/uni2.png',
-    '/universities/uni3.png',
-    '/universities/uni4.png',
-    '/universities/uni5.png',
+    'https://picsum.photos/seed/uni1/600/300',
+    'https://picsum.photos/seed/uni2/600/300',
+    'https://picsum.photos/seed/uni3/600/300',
+    'https://picsum.photos/seed/uni4/600/300',
+    'https://picsum.photos/seed/uni5/600/300',
   ];
   const fallback = fallbacks[Math.floor(Math.random() * fallbacks.length)];
   const chosenSrc = !src || error ? fallback : src;

--- a/src/data/universities.ts
+++ b/src/data/universities.ts
@@ -19,7 +19,7 @@ export const universities: University[] = [
     ],
     description:
       'تأسست جامعة ملايا عام 1905، وهي أقدم وأعرق جامعة في ماليزيا. تتميز ببرامجها البحثية المتقدمة وتصنيفها العالمي المرتفع.',
-    imageUrl: '/universities/uni1.png',
+    imageUrl: 'https://picsum.photos/seed/uni1/600/300',
     livingCosts: 'USD 320-540 شهريًا',
     acceptanceCriteria: [
       'شهادة الثانوية العامة بمعدل ممتاز',
@@ -49,7 +49,7 @@ export const universities: University[] = [
     ],
     description:
       'Known for its focus on scientific research and innovation, offering a wide range of science and applied disciplines.',
-    imageUrl: '/universities/uni2.png',
+    imageUrl: 'https://picsum.photos/seed/uni2/600/300',
     livingCosts: 'USD 320-540 monthly',
     acceptanceCriteria: [
       'High school certificate with very good grades',
@@ -77,7 +77,7 @@ export const universities: University[] = [
     ],
     description:
       'Established to promote the Malay language and culture, a leading university in humanities and social sciences.',
-    imageUrl: '/universities/uni3.png',
+    imageUrl: 'https://picsum.photos/seed/uni3/600/300',
     livingCosts: 'USD 320-540 monthly',
     acceptanceCriteria: [
       'High school certificate',
@@ -106,7 +106,7 @@ export const universities: University[] = [
     ],
     description:
       'Distinguished for its strong programs in agriculture and related sciences, a major research center in this field.',
-    imageUrl: '/universities/uni4.png',
+    imageUrl: 'https://picsum.photos/seed/uni4/600/300',
     livingCosts: 'USD 320-540 monthly',
     acceptanceCriteria: [
       'High school certificate',
@@ -133,7 +133,7 @@ export const universities: University[] = [
     ],
     description:
       'A leader in engineering and technology, renowned for its highly competent graduates.',
-    imageUrl: '/universities/uni5.png',
+    imageUrl: 'https://picsum.photos/seed/uni5/600/300',
     livingCosts: 'USD 320-540 monthly',
     acceptanceCriteria: [
       'High school certificate with excellent grades in science subjects',


### PR DESCRIPTION
## Summary
- replace missing local university images with random pics from picsum.photos
- update SmartImage fallback to use remote placeholders and add picsum domain
- adjust test page to verify new images load

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a0a2f4d538832b8074531830070548